### PR TITLE
ITFISCORE-1013: reintroduced documented usage of default instance var…

### DIFF
--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultEntitySerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultEntitySerializer.java
@@ -346,6 +346,7 @@ public class DefaultEntitySerializer implements EntitySerializer {
 				writer.append("    public static final class Constants {\n  ");
         writer.publicStaticFinal(queryType, simpleName, NEW + queryType.getSimpleName() + "(\"" + alias + "\")");
 				writer.append("    }\n");
+        writer.publicStaticFinal(queryType, simpleName, "Constants." + simpleName);
     }
 
     protected void introFactoryMethods(CodeWriter writer, final EntityType model) throws IOException {


### PR DESCRIPTION
# Purpose:

Reintroduce the documented usage of the default instance variable while maintaining the deadlock fix. 

# Rationale:

The previous fix ([ITFISCORE-1013 wrap public static final field in Constants class](https://github.com/querydsl/querydsl/commit/c78eea657a93bf872c60f1598253dab89e32a7a0)) effectively secured QueryDSL from potential locking problems with singleton instances for generated QClasses. However, it also disrupted the documented and well-known functionality of the default instance variable.

This small update restores the broken functionality by generating an additional line of code that reintroduces the default static instance. It achieves this by utilizing the lazy-initialization singleton holder pattern to retain the added thread-safety.

# Example code generated after this change:

```
    @Generated("FIS")
    public static final class Constants {
      public static final QSubscription subscription = new QSubscription("subscription");

    }
    public static final QSubscription subscription = Constants.subscription;
```
    
As shown above, the static inner class wrapper fix remains intact (and stays public to avoid breaking already-migrated user code). We simply reintroduce the default instance variable and point it to the new, thread-safe, lazy-initialized singleton.
    